### PR TITLE
stv0910: release lock on gate_ctrl() failure

### DIFF
--- a/frontends/stv0910.c
+++ b/frontends/stv0910.c
@@ -1198,17 +1198,22 @@ static int gate_ctrl(struct dvb_frontend *fe, int enable)
 	struct stv *state = fe->demodulator_priv;
 	u8 i2crpt = state->i2crpt & ~0x86;
 
-	if (enable)
+	if (enable) {
 		mutex_lock(&state->base->i2c_lock);
-
-	if (enable)
 		i2crpt |= 0x80;
-	else
+	} else {
 		i2crpt |= 0x02;
+	}
 
 	if (write_reg(state, state->nr ? RSTV0910_P2_I2CRPT :
-		      RSTV0910_P1_I2CRPT, i2crpt) < 0)
+		      RSTV0910_P1_I2CRPT, i2crpt) < 0) {
+		/* don't hold the I2C bus lock on failure */
+		mutex_unlock(&state->base->i2c_lock);
+		dev_err(&state->base->i2c->dev,
+			"%s() write_reg failure (enable=%d)\n",
+			__func__, enable);
 		return -EIO;
+	}
 
 	state->i2crpt = i2crpt;
 


### PR DESCRIPTION
When write_reg() fails, the mutex_unlock() won't ever be hit especially
when closing the I2C gate. This can lead to deadlock situations, even
(or, especially) if the i2c_gate_ctrl status isn't checked in stv6111.
Fix this possibility by releasing the lock whenever write_reg() fails.