### PR TITLE
stv6111: return NULL instead of plain integer

### DIFF
--- a/frontends/stv6111.c
+++ b/frontends/stv6111.c
@@ -732,7 +732,7 @@ struct dvb_frontend *stv6111_attach(struct dvb_frontend *fe,
 		fe->ops.i2c_gate_ctrl(fe, 0);
 	if (stat < 0) {
 		kfree(state);
-		return 0;
+		return NULL;
 	}
 	fe->tuner_priv = state;
 	return fe;


### PR DESCRIPTION
Fixes sparse warning:
  frontends/stv6111.c:735:24: warning: Using plain integer as NULL pointer